### PR TITLE
fix Peer id invalid

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -4,12 +4,16 @@ from aiohttp import web
 from plugins import web_server
 
 import pyromod.listen
+import pyrogram
 from pyrogram import Client
 from pyrogram.enums import ParseMode
 import sys
 from datetime import datetime
 
 from config import API_HASH, APP_ID, LOGGER, TG_BOT_TOKEN, TG_BOT_WORKERS, FORCE_SUB_CHANNEL, CHANNEL_ID, PORT
+
+pyrogram.utils.MIN_CHAT_ID = -999999999999
+pyrogram.utils.MIN_CHANNEL_ID = -100999999999999
 
 class Bot(Client):
     def __init__(self):


### PR DESCRIPTION
Pyrogram considers new 64 channel ids as small group. We can fix this by changing `MIN_CHANNEL_ID`.